### PR TITLE
Fix RHEL detection for SLES

### DIFF
--- a/php-fpmpal.sh
+++ b/php-fpmpal.sh
@@ -336,7 +336,7 @@ echo -n "Memory available to assign to PHP-FPM pools in KB: "
    # RHEL 7's free reports look different to CentOS6, Ubuntu 14 and Debian 8 so I have to 1) check whether this is RHEL/CentOS 7, and 2) if it is, use different formulas
    rhel7_check=0
    if [ -f /etc/redhat-release ]; then
-      rhel7_check=`cat /etc/redhat-release | awk -F "release" '{print $2}' | awk '{print $1}' | cut -d. -f1` > /dev/null
+      rhel7_check=`grep -v ^# /etc/redhat-release | awk -F "release" '{print $2}' | awk '{print $1}' | cut -d. -f1` > /dev/null
    fi
    # If this is RHEL 7 then use this formula
    if [ $rhel7_check == '7' ]; then


### PR DESCRIPTION
Currently picks up the duplicated version line. By excluding the commented lines, we should resolve this.

```
[...]
Memory available to assign to PHP-FPM pools in KB: sh: line 342: [: too many arguments
21465964 (total free memory + PHP-FPM's current memory usage)
[...]


[root@servername ~]# cat /etc/redhat-release
Red Hat Enterprise Linux Server release 6.7 (Santiago)
# This is a "SLES Expanded Support platform release 6.7"
# The above "Red Hat Enterprise Linux Server" string is only used to
# keep software compatibility.

[root@servername ~]# cat /etc/redhat-release | awk -F "release" '{print $2}' | awk '{print $1}' | cut -d. -f1
6
6


[root@servername ~]# grep -v ^# /etc/redhat-release | awk -F "release" '{print $2}' | awk '{print $1}' | cut -d. -f1
6
```
